### PR TITLE
Update terasort from plugin to resource manger

### DIFF
--- a/test_plans/realtime-syslog-analytics.yaml
+++ b/test_plans/realtime-syslog-analytics.yaml
@@ -1,6 +1,6 @@
 bundle: bundle:realtime-syslog-analytics
 benchmark:
-    plugin:
+    resourcemanager:
         terasort
 bundle_name: realtime-syslog-analytics
 bundle_file: bundle.yaml


### PR DESCRIPTION
The resourcemanager service (apache-hadoop-resourcemanager charm) is where the terasort benchmark lives. Updating the test plan to reflect this.